### PR TITLE
#26 API 스펙 변경

### DIFF
--- a/ppap/src/main/java/com/ppap/ppap/_core/rss/RssReader.java
+++ b/ppap/src/main/java/com/ppap/ppap/_core/rss/RssReader.java
@@ -4,7 +4,8 @@ import com.ppap.ppap._core.exception.BaseExceptionStatus;
 import com.ppap.ppap._core.exception.Exception400;
 import com.ppap.ppap._core.exception.Exception500;
 import com.ppap.ppap._core.exception.Exception502;
-import com.ppap.ppap.domain.subscribe.entity.Notice;
+import com.ppap.ppap._core.utils.UrlFactory;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jdom2.Document;
@@ -12,9 +13,7 @@ import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,7 +21,6 @@ import java.net.*;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 

--- a/ppap/src/main/java/com/ppap/ppap/_core/utils/UrlFactory.java
+++ b/ppap/src/main/java/com/ppap/ppap/_core/utils/UrlFactory.java
@@ -1,4 +1,4 @@
-package com.ppap.ppap._core.rss;
+package com.ppap.ppap._core.utils;
 
 import org.springframework.stereotype.Component;
 

--- a/ppap/src/main/java/com/ppap/ppap/application/usecase/GetScrapSubscirbeUseCase.java
+++ b/ppap/src/main/java/com/ppap/ppap/application/usecase/GetScrapSubscirbeUseCase.java
@@ -41,6 +41,6 @@ public class GetScrapSubscirbeUseCase {
                 pageable);
 
 
-        return ScrapWithSubscribeDto.of(subscribeList, curSubscribeId, scrapList);
+        return ScrapWithSubscribeDto.of(curSubscribeId, scrapList);
     }
 }

--- a/ppap/src/main/java/com/ppap/ppap/application/usecase/GetSubscribeContentUseCase.java
+++ b/ppap/src/main/java/com/ppap/ppap/application/usecase/GetSubscribeContentUseCase.java
@@ -38,7 +38,8 @@ public class GetSubscribeContentUseCase {
         // 현재 클릭한 subscribe
         Subscribe curSubcribe = subscribeList.stream()
                 .filter(subscribe -> subscribe.getId().equals(curSubscribeId))
-                .findFirst().orElseThrow(() -> new Exception404(BaseExceptionStatus.SUBSCRIBE_NOT_FOUND));
+                .findFirst()
+                .orElseThrow(() -> new Exception404(BaseExceptionStatus.SUBSCRIBE_NOT_FOUND));
 
         // 현재 클릭한 구독의 컨텐츠들
         // One To Many sql 1번 vs notice 1번, content 1번 -> 총 2번 (이거 선택)
@@ -52,6 +53,6 @@ public class GetSubscribeContentUseCase {
                 .map(ScrapFindByContentIdDto::contentId)
                 .collect(Collectors.toSet());
 
-        return SubscribeWithContentScrapDto.of(subscribeList, curSubscribeId, contentList, scrapContentIdSet);
+        return SubscribeWithContentScrapDto.of(curSubscribeId, contentList, scrapContentIdSet);
     }
 }

--- a/ppap/src/main/java/com/ppap/ppap/domain/scrap/dto/ScrapWithSubscribeDto.java
+++ b/ppap/src/main/java/com/ppap/ppap/domain/scrap/dto/ScrapWithSubscribeDto.java
@@ -8,7 +8,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record ScrapWithSubscribeDto(
-        List<SubscribeDto> subscribes,
         Long curSubscribeId,
         List<ScrapDto> scraps
 ) {
@@ -53,11 +52,9 @@ public record ScrapWithSubscribeDto(
         }
     }
 
-    public static ScrapWithSubscribeDto of(List<Subscribe> subscribeList, Long curSubscribeId, List<Scrap> scrapList) {
-        List<SubscribeDto> subscribes = subscribeList.stream().map(SubscribeDto::of).toList();
+    public static ScrapWithSubscribeDto of(Long curSubscribeId, List<Scrap> scrapList) {
         List<ScrapDto> scraps = scrapList.stream().map(ScrapDto::of).toList();
         return ScrapWithSubscribeDto.builder()
-                .subscribes(subscribes)
                 .curSubscribeId(curSubscribeId)
                 .scraps(scraps)
                 .build();

--- a/ppap/src/main/java/com/ppap/ppap/domain/subscribe/dto/SubscribeWithContentScrapDto.java
+++ b/ppap/src/main/java/com/ppap/ppap/domain/subscribe/dto/SubscribeWithContentScrapDto.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Set;
 
 public record SubscribeWithContentScrapDto(
-        List<SubscribeDto> subscribes,
         Long curSubscribeId,
         List<ContentScrapDto>  contents
         ) {
@@ -52,17 +51,14 @@ public record SubscribeWithContentScrapDto(
         }
     }
 
-    public static SubscribeWithContentScrapDto of(List<Subscribe> subscribeList,
-                                                  Long curSubscribeId,
+    public static SubscribeWithContentScrapDto of(Long curSubscribeId,
                                                   List<Content> contentList,
                                                   Set<Long> scrapContentIdSet) {
 
-        List<SubscribeDto> subscribes = subscribeList.stream().map(SubscribeDto::of).toList();
         List<ContentScrapDto> contents = contentList.stream()
                 .map(content -> ContentScrapDto.of(content, scrapContentIdSet)).toList();
 
         return SubscribeWithContentScrapDto.builder()
-                .subscribes(subscribes)
                 .curSubscribeId(curSubscribeId)
                 .contents(contents)
                 .build();

--- a/ppap/src/main/java/com/ppap/ppap/domain/subscribe/entity/Content.java
+++ b/ppap/src/main/java/com/ppap/ppap/domain/subscribe/entity/Content.java
@@ -32,7 +32,7 @@ public class Content {
     @JoinColumn(name = "notice_id", nullable = false)
     private Notice notice;
 
-    @Column(length = 100, nullable = false)
+    @Column(nullable = false)
     private String title;
 
     @Column(nullable = false)

--- a/ppap/src/test/java/com/ppap/ppap/controller/ContentControllerTest.java
+++ b/ppap/src/test/java/com/ppap/ppap/controller/ContentControllerTest.java
@@ -38,12 +38,6 @@ public class ContentControllerTest extends RestDocs {
             // then
             resultActions.andExpectAll(
                     jsonPath("$.success").value("true"),
-                    jsonPath("$.response.subscribes[0].subscribeId").value(1L),
-                    jsonPath("$.response.subscribes[1].subscribeId").value(2L),
-                    jsonPath("$.response.subscribes[2].subscribeId").value(3L),
-                    jsonPath("$.response.subscribes[0].title").value("테스트1"),
-                    jsonPath("$.response.subscribes[1].title").value("테스트2"),
-                    jsonPath("$.response.subscribes[2].title").value("테스트3"),
                     jsonPath("$.response.curSubscribeId").value(1L),
                     jsonPath("$.response.contents[0].contentId").value(1L),
                     jsonPath("$.response.contents[0].isScraped").value("true"),
@@ -106,12 +100,6 @@ public class ContentControllerTest extends RestDocs {
             // then
             resultActions.andExpectAll(
                     jsonPath("$.success").value("true"),
-                    jsonPath("$.response.subscribes[0].subscribeId").value(1L),
-                    jsonPath("$.response.subscribes[1].subscribeId").value(2L),
-                    jsonPath("$.response.subscribes[2].subscribeId").value(3L),
-                    jsonPath("$.response.subscribes[0].title").value("테스트1"),
-                    jsonPath("$.response.subscribes[1].title").value("테스트2"),
-                    jsonPath("$.response.subscribes[2].title").value("테스트3"),
                     jsonPath("$.response.curSubscribeId").value(1L),
                     jsonPath("$.response.contents[0].contentId").value(11L),
                     jsonPath("$.response.contents[0].isScraped").value("true"),
@@ -149,12 +137,6 @@ public class ContentControllerTest extends RestDocs {
             // then
             resultActions.andExpectAll(
                     jsonPath("$.success").value("true"),
-                    jsonPath("$.response.subscribes[0].subscribeId").value(1L),
-                    jsonPath("$.response.subscribes[1].subscribeId").value(2L),
-                    jsonPath("$.response.subscribes[2].subscribeId").value(3L),
-                    jsonPath("$.response.subscribes[0].title").value("테스트1"),
-                    jsonPath("$.response.subscribes[1].title").value("테스트2"),
-                    jsonPath("$.response.subscribes[2].title").value("테스트3"),
                     jsonPath("$.response.curSubscribeId").value(2L),
                     jsonPath("$.response.contents[0].contentId").value(18L),
                     jsonPath("$.response.contents[0].isScraped").value("false"),

--- a/ppap/src/test/java/com/ppap/ppap/controller/ScrapControllerTest.java
+++ b/ppap/src/test/java/com/ppap/ppap/controller/ScrapControllerTest.java
@@ -188,9 +188,6 @@ public class ScrapControllerTest extends RestDocs {
             // then
             resultActions.andExpectAll(
                     jsonPath("$.success").value("true"),
-                    jsonPath("$.response.subscribes[0].subscribeId").value(1L),
-                    jsonPath("$.response.subscribes[1].subscribeId").value(2L),
-                    jsonPath("$.response.subscribes[2].subscribeId").value(3L),
                     jsonPath("$.response.curSubscribeId").value(1L),
                     jsonPath("$.response.scraps[0].contentId").value(1L),
                     jsonPath("$.response.scraps[1].contentId").value(2L),
@@ -240,9 +237,6 @@ public class ScrapControllerTest extends RestDocs {
             // then
             resultActions.andExpectAll(
                     jsonPath("$.success").value("true"),
-                    jsonPath("$.response.subscribes[0].subscribeId").value(1L),
-                    jsonPath("$.response.subscribes[1].subscribeId").value(2L),
-                    jsonPath("$.response.subscribes[2].subscribeId").value(3L),
                     jsonPath("$.response.curSubscribeId").value(1L),
                     jsonPath("$.response.scraps[0].contentId").value(17L),
                     jsonPath("$.error").doesNotExist()
@@ -266,9 +260,6 @@ public class ScrapControllerTest extends RestDocs {
             // then
             resultActions.andExpectAll(
                     jsonPath("$.success").value("true"),
-                    jsonPath("$.response.subscribes[0].subscribeId").value(1L),
-                    jsonPath("$.response.subscribes[1].subscribeId").value(2L),
-                    jsonPath("$.response.subscribes[2].subscribeId").value(3L),
                     jsonPath("$.response.curSubscribeId").value(2L),
                     jsonPath("$.response.scraps[0].contentId").value(19L),
                     jsonPath("$.response.scraps[1].contentId").value(21L),

--- a/ppap/src/test/java/com/ppap/ppap/controller/SubscribeControllerTest.java
+++ b/ppap/src/test/java/com/ppap/ppap/controller/SubscribeControllerTest.java
@@ -5,7 +5,7 @@ import com.epages.restdocs.apispec.SimpleType;
 
 import com.ppap.ppap._core.RestDocs;
 import com.ppap.ppap._core.exception.BaseExceptionStatus;
-import com.ppap.ppap._core.rss.UrlFactory;
+import com.ppap.ppap._core.utils.UrlFactory;
 import com.ppap.ppap._core.security.JwtProvider;
 import com.ppap.ppap.domain.subscribe.dto.SubscribeCreateRequestDto;
 import com.ppap.ppap.domain.subscribe.dto.SubscribeUpdateRequestDto;
@@ -14,7 +14,6 @@ import org.jdom2.input.SAXBuilder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -22,7 +21,6 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.InputStream;
-import java.net.URL;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.*;

--- a/ppap/src/test/java/com/ppap/ppap/service/rss/RssReaderServiceTest.java
+++ b/ppap/src/test/java/com/ppap/ppap/service/rss/RssReaderServiceTest.java
@@ -4,37 +4,30 @@ import com.ppap.ppap._core.exception.BaseExceptionStatus;
 import com.ppap.ppap._core.exception.Exception400;
 import com.ppap.ppap._core.rss.RssData;
 import com.ppap.ppap._core.rss.RssReader;
-import com.ppap.ppap._core.rss.UrlFactory;
+import com.ppap.ppap._core.utils.UrlFactory;
 import com.ppap.ppap.domain.subscribe.entity.Notice;
 import org.jdom2.Document;
-import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/ppap/src/test/java/com/ppap/ppap/service/subscribe/SubscribeWriteServiceTest.java
+++ b/ppap/src/test/java/com/ppap/ppap/service/subscribe/SubscribeWriteServiceTest.java
@@ -7,7 +7,7 @@ import com.ppap.ppap._core.exception.Exception400;
 import com.ppap.ppap._core.exception.Exception403;
 import com.ppap.ppap._core.exception.Exception404;
 import com.ppap.ppap._core.rss.RssReader;
-import com.ppap.ppap._core.rss.UrlFactory;
+import com.ppap.ppap._core.utils.UrlFactory;
 import com.ppap.ppap.domain.subscribe.dto.SubscribeCreateRequestDto;
 import com.ppap.ppap.domain.subscribe.dto.SubscribeUpdateRequestDto;
 import com.ppap.ppap.domain.subscribe.dto.SubscribeUpdateResponseDto;

--- a/ppap/src/test/java/com/ppap/ppap/service/usecase/GetScrapSubscirbeUseCaseTest.java
+++ b/ppap/src/test/java/com/ppap/ppap/service/usecase/GetScrapSubscirbeUseCaseTest.java
@@ -73,7 +73,6 @@ public class GetScrapSubscirbeUseCaseTest {
 
             // then
             assertEquals(1L, response.curSubscribeId());
-            assertEquals(22, response.subscribes().size());
             assertEquals(10, response.scraps().size());
             for (int i=1; i<11; i++) {
                 assertEquals(true, response.scraps().get(i-1).isScrap());
@@ -107,7 +106,6 @@ public class GetScrapSubscirbeUseCaseTest {
 
             // then
             assertEquals(1L, response.curSubscribeId());
-            assertEquals(22, response.subscribes().size());
             assertEquals(2, response.scraps().size());
             for (int i=0; i<response.scraps().size(); i++) {
                 assertEquals(11+i, response.scraps().get(i).contentId());
@@ -141,7 +139,6 @@ public class GetScrapSubscirbeUseCaseTest {
 
             // then
             assertEquals(2L, response.curSubscribeId());
-            assertEquals(22, response.subscribes().size());
             assertEquals(10, response.scraps().size());
             for (int i=1; i<11; i++) {
                 assertEquals(true, response.scraps().get(i-1).isScrap());

--- a/ppap/src/test/java/com/ppap/ppap/service/usecase/GetSubscribeContentUseCaseTest.java
+++ b/ppap/src/test/java/com/ppap/ppap/service/usecase/GetSubscribeContentUseCaseTest.java
@@ -82,7 +82,6 @@ public class GetSubscribeContentUseCaseTest {
             // then
             verify(contentReadService, times(1)).findByNoticeId(curSubscribeId.capture(), any());
             assertEquals(curSubscribeId.getValue(), 1L);
-            assertEquals(22, response.subscribes().size());
             assertEquals(10, response.contents().size());
             for (int i=0; i<5; i++) {
                 assertEquals(true, response.contents().get(i).isScraped());
@@ -119,7 +118,6 @@ public class GetSubscribeContentUseCaseTest {
             // then
             verify(contentReadService, times(1)).findByNoticeId(curSubscribeId.capture(), any());
             assertEquals(curSubscribeId.getValue(), 1L);
-            assertEquals(22, response.subscribes().size());
             assertEquals(2, response.contents().size());
             for (int i=0; i<response.contents().size(); i++) {
                 assertEquals(false, response.contents().get(i).isScraped());
@@ -153,7 +151,6 @@ public class GetSubscribeContentUseCaseTest {
             // then
             verify(contentReadService, times(1)).findByNoticeId(curSubscribeId.capture(), any());
             assertEquals(curSubscribeId.getValue(), 2L);
-            assertEquals(22, response.subscribes().size());
             assertEquals(10, response.contents().size());
             for (int i=0; i<response.contents().size(); i++) {
                 assertEquals(false, response.contents().get(i).isScraped());


### PR DESCRIPTION
- 기존 공지사항 및 스크랩 조회 화면에 사용하는 Subscribe 데이터는 기존에 API에 중복되기에 제거했습니다.
- 테스트 중 공지사항의 제목이 100자를 넘어가는 경우가 있어 Content 엔티티의 Title 길이를 255자로 증가시켰습니다.