### PR TITLE
#56 Implement Subscribe Priority

### DIFF
--- a/ppap/src/main/java/com/ppap/ppap/_core/batch/NoticeWriter.java
+++ b/ppap/src/main/java/com/ppap/ppap/_core/batch/NoticeWriter.java
@@ -130,7 +130,7 @@ public class NoticeWriter implements ItemWriter<NoticeDto> {
 
 	private boolean syncNoticeData(Notice notice, NoticeDto noticeDto, Map<String, Univ> univIdMap) {
 		String collegeDepartment = String.format("%s_%s", noticeDto.college(), noticeDto.department());
-		if (!notice.getUniv().equals(univIdMap.get(collegeDepartment))){
+		if (notice.getUniv() == null || !notice.getUniv().equals(univIdMap.get(collegeDepartment))){
 			notice.changeUniv(univIdMap.get(collegeDepartment));
 			return true;
 		}

--- a/ppap/src/main/java/com/ppap/ppap/_core/utils/converter/NullToMaxIntegerConverter.java
+++ b/ppap/src/main/java/com/ppap/ppap/_core/utils/converter/NullToMaxIntegerConverter.java
@@ -1,0 +1,25 @@
+package com.ppap.ppap._core.utils.converter;
+
+import java.util.Objects;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+//autoApply True시 모든 엔티티의 Integer필드에 대해서 자동 적용되므로 주의해야한다.
+@Converter
+public class NullToMaxIntegerConverter implements AttributeConverter<Integer, Integer> {
+	@Override
+	public Integer convertToDatabaseColumn(Integer attribute) {
+		//특별한 변환 없이 그대로 값을 데이터베이스에 저장.
+		return attribute;
+	}
+
+	@Override
+	public Integer convertToEntityAttribute(Integer dbData) {
+		// 데이터베이스에서 읽은 값이 null이면 Integer.MAX_VALUE로 변환
+		if (Objects.isNull(dbData))
+			return Integer.MAX_VALUE;
+
+		return dbData;
+	}
+}

--- a/ppap/src/main/java/com/ppap/ppap/application/controller/SubscribeController.java
+++ b/ppap/src/main/java/com/ppap/ppap/application/controller/SubscribeController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Validated
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("api/v0/subscribe")
@@ -60,6 +59,15 @@ public class SubscribeController {
 
         SubscribeUpdateResponseDto resultDto = subscribeWriteService.activeUpdate(subscribeId, userDetails.getUser());
         return ResponseEntity.ok(ApiUtils.success(resultDto));
+    }
+
+    @PostMapping("/change/priority")
+    public ResponseEntity<?> changePriority(@Valid @RequestBody SubscribeChangePriorityDto subscribeChangePriorityDto,
+                                            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        subscribeWriteService.changePriority(subscribeChangePriorityDto.subscribeIds(), userDetails.getUser());
+
+        return ResponseEntity.ok(ApiUtils.success(null));
     }
 
     @PostMapping("/delete/{subscribe_id}")

--- a/ppap/src/main/java/com/ppap/ppap/application/usecase/GetScrapSubscirbeUseCase.java
+++ b/ppap/src/main/java/com/ppap/ppap/application/usecase/GetScrapSubscirbeUseCase.java
@@ -25,7 +25,6 @@ public class GetScrapSubscirbeUseCase {
     public ScrapWithSubscribeDto execute(Optional<Long> subscribeId, User user, Pageable pageable) {
         // 등록중인 subscribe
         List<Subscribe> subscribeList = subscribeReadService.getSubscribeEntityList(user);
-        subscribeList.sort(Comparator.comparing(Subscribe::getId));
 
         // 현재 클릭한 subscribeId
         Long curSubscribeId = subscribeId.orElse(subscribeList.get(0).getId());

--- a/ppap/src/main/java/com/ppap/ppap/application/usecase/GetSubscribeContentUseCase.java
+++ b/ppap/src/main/java/com/ppap/ppap/application/usecase/GetSubscribeContentUseCase.java
@@ -30,7 +30,6 @@ public class GetSubscribeContentUseCase {
     public SubscribeWithContentScrapDto execute(Optional<Long> subscribeId, User user, Pageable pageable) {
         // 등록중인 subscribes
         List<Subscribe> subscribeList = subscribeReadService.getSubscribeEntityList(user);
-        subscribeList.sort(Comparator.comparing(Subscribe::getId));
 
         // 현재 클릭 중인 subscribeId
         Long curSubscribeId = subscribeId.orElse(subscribeList.get(0).getId());

--- a/ppap/src/main/java/com/ppap/ppap/domain/subscribe/dto/SubscribeChangePriorityDto.java
+++ b/ppap/src/main/java/com/ppap/ppap/domain/subscribe/dto/SubscribeChangePriorityDto.java
@@ -1,0 +1,12 @@
+package com.ppap.ppap.domain.subscribe.dto;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public record SubscribeChangePriorityDto(
+	@NotEmpty(message = "데이터를 입력해주세요.")
+	List<@NotNull(message = "Null을 입력해선 안됩니다.") Long> subscribeIds
+) {
+}

--- a/ppap/src/main/java/com/ppap/ppap/domain/subscribe/entity/Subscribe.java
+++ b/ppap/src/main/java/com/ppap/ppap/domain/subscribe/entity/Subscribe.java
@@ -57,7 +57,7 @@ public class Subscribe extends AuditingEntity {
         this.notice = notice;
         this.noticeLink = noticeLink;
         this.isActive = isActive;
-        this.priority = priority;
+        this.priority = Objects.isNull(priority) ? Integer.MAX_VALUE : priority;
     }
 
     public static Subscribe of(User user, Notice notice, String title, String noticeLink, Boolean isActive) {

--- a/ppap/src/main/java/com/ppap/ppap/domain/subscribe/entity/Subscribe.java
+++ b/ppap/src/main/java/com/ppap/ppap/domain/subscribe/entity/Subscribe.java
@@ -1,5 +1,6 @@
 package com.ppap.ppap.domain.subscribe.entity;
 
+import com.ppap.ppap._core.utils.converter.NullToMaxIntegerConverter;
 import com.ppap.ppap.domain.base.entity.AuditingEntity;
 import com.ppap.ppap.domain.user.entity.User;
 import jakarta.persistence.*;
@@ -11,7 +12,7 @@ import org.hibernate.annotations.OnDeleteAction;
 import java.util.Objects;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString(exclude = {"user", "notice"})
+@ToString(exclude = {"user", "notice"}, callSuper = true)
 @Entity
 @Getter
 @Table(name = "subscribe_tb", uniqueConstraints = {
@@ -44,14 +45,19 @@ public class Subscribe extends AuditingEntity {
     @Column(nullable = false)
     private Boolean isActive;
 
+    // default값은 정수 최대값 -> 우선순위 제일 낮음
+    @Convert(converter = NullToMaxIntegerConverter.class)
+    private Integer priority = Integer.MAX_VALUE;
+
     @Builder
-    public Subscribe(Long id, String title, User user, Notice notice, String noticeLink, Boolean isActive) {
+    public Subscribe(Long id, String title, User user, Notice notice, String noticeLink, Boolean isActive, Integer priority) {
         this.id = id;
         this.title = title;
         this.user = user;
         this.notice = notice;
         this.noticeLink = noticeLink;
         this.isActive = isActive;
+        this.priority = priority;
     }
 
     public static Subscribe of(User user, Notice notice, String title, String noticeLink, Boolean isActive) {
@@ -75,6 +81,10 @@ public class Subscribe extends AuditingEntity {
 
     public void changeActive(){
         this.isActive = !this.isActive;
+    }
+
+    public void changePriority(Integer priority) {
+        this.priority = priority;
     }
 
     @Override

--- a/ppap/src/main/java/com/ppap/ppap/domain/subscribe/service/SubscribeReadService.java
+++ b/ppap/src/main/java/com/ppap/ppap/domain/subscribe/service/SubscribeReadService.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
@@ -30,13 +31,17 @@ public class SubscribeReadService {
         List<Subscribe> subscribeList = subscribeJpaRepository.findByUserId(user.getId());
         if (subscribeList.isEmpty()) throw new Exception404(BaseExceptionStatus.SUBSCRIBE_EMPTY);
 
-        return subscribeList;
+        return subscribeList.stream()
+            .sorted(Comparator.comparing(Subscribe::getPriority)
+                .thenComparing(Subscribe::getId))
+            .toList();
     }
 
     public List<SubscribeGetListResponseDto> getSubscribeList(User user) {
         List<Subscribe> subscribeList = subscribeJpaRepository.findByUserId(user.getId());
-
         return subscribeList.stream()
+                .sorted(Comparator.comparing(Subscribe::getPriority)
+                    .thenComparing(Subscribe::getId))
                 .map(SubscribeGetListResponseDto::of)
                 .toList();
     }

--- a/ppap/src/main/java/com/ppap/ppap/domain/subscribe/service/SubscribeWriteService.java
+++ b/ppap/src/main/java/com/ppap/ppap/domain/subscribe/service/SubscribeWriteService.java
@@ -1,5 +1,10 @@
 package com.ppap.ppap.domain.subscribe.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import com.ppap.ppap._core.exception.BaseExceptionStatus;
 import com.ppap.ppap._core.exception.Exception400;
 import com.ppap.ppap._core.exception.Exception403;
@@ -89,6 +94,24 @@ public class SubscribeWriteService {
         validSubscribeWriter(subscribe, user);
 
         subscribeJpaRepository.delete(subscribe);
+    }
+
+    public void changePriority(List<Long> subscribeIds, User user) {
+        Map<Long, Subscribe> subscribeMap = subscribeJpaRepository.findAllById(subscribeIds)
+            .stream()
+            .collect(Collectors.toMap(
+                Subscribe::getId,
+                subscribe -> subscribe
+            ));
+
+        if (subscribeIds.size() != subscribeMap.keySet().size())
+            throw new Exception404(BaseExceptionStatus.SUBSCRIBE_NOT_FOUND);
+
+        subscribeMap.values().forEach(subscribe -> validSubscribeWriter(subscribe, user));
+
+        IntStream.range(0, subscribeIds.size())
+            .forEach(idx -> subscribeMap.get(subscribeIds.get(idx)).changePriority(idx));
+
     }
 
     /**

--- a/ppap/src/main/resources/db/teardown.sql
+++ b/ppap/src/main/resources/db/teardown.sql
@@ -24,12 +24,12 @@ VALUES (3, 'https://chemeng.pusan.ac.kr/bbs/chemeng/2870/rssList.do', CURRENT_TI
 INSERT INTO notice_tb (`notice_id`, `link`, `last_time`, `created_at`, `last_modified_at`, `notice_type`)
 VALUES (4, 'https://french.pusan.ac.kr/bbs/french/4295/rssList.do', CURRENT_TIMESTAMP, '2023-08-08 23:54:29.966', '2023-08-08 23:54:29.966', 'RSS');
 
-INSERT INTO subscribe_tb (`subscribe_id`, `title`, `user_id`, `notice_id`, `notice_link`, `is_active`, `created_at`, `last_modified_at`)
-VALUES (1, '테스트1', 1, 1, NULL, TRUE, '2023-08-08 23:54:29.966', '2023-08-08 23:54:29.966');
-INSERT INTO subscribe_tb (`subscribe_id`, `title`, `user_id`, `notice_id`, `notice_link`, `is_active`, `created_at`, `last_modified_at`)
-VALUES (2, '테스트2', 1, 2, 'https://cse.pusan.ac.kr/cse/14655/subview.do', TRUE, '2023-08-08 23:54:29.966', '2023-08-08 23:54:29.966');
-INSERT INTO subscribe_tb (`subscribe_id`, `title`, `user_id`, `notice_id`, `notice_link`, `is_active`, `created_at`, `last_modified_at`)
-VALUES (3, '테스트3', 1, 3, NULL, TRUE, '2023-08-08 23:54:29.966', '2023-08-08 23:54:29.966');
+INSERT INTO subscribe_tb (`subscribe_id`, `title`, `user_id`, `notice_id`, `notice_link`, `is_active`, `created_at`, `last_modified_at`, `priority`)
+VALUES (1, '테스트1', 1, 1, NULL, TRUE, '2023-08-08 23:54:29.966', '2023-08-08 23:54:29.966', NULL);
+INSERT INTO subscribe_tb (`subscribe_id`, `title`, `user_id`, `notice_id`, `notice_link`, `is_active`, `created_at`, `last_modified_at`, `priority`)
+VALUES (2, '테스트2', 1, 2, 'https://cse.pusan.ac.kr/cse/14655/subview.do', TRUE, '2023-08-08 23:54:29.966', '2023-08-08 23:54:29.966', 0);
+INSERT INTO subscribe_tb (`subscribe_id`, `title`, `user_id`, `notice_id`, `notice_link`, `is_active`, `created_at`, `last_modified_at`, `priority`)
+VALUES (3, '테스트3', 1, 3, NULL, TRUE, '2023-08-08 23:54:29.966', '2023-08-08 23:54:29.966', 1);
 
 
 INSERT INTO content_tb (`content_id`, `notice_id`, `pub_date`, `author`, `category`, `title`, `link`)

--- a/ppap/src/main/resources/db/teardown.sql
+++ b/ppap/src/main/resources/db/teardown.sql
@@ -99,6 +99,8 @@ VALUES (32, 2, '2023-04-04 14:00:26.197', '임준영', '2023', '[유영환 교�
 INSERT INTO content_tb (`content_id`, `notice_id`, `pub_date`, `author`, `category`, `title`, `link`)
 VALUES (33, 2, '2023-04-04 11:49:45.967', '최현재', '2023', '[채흥석 교수] 2023년 졸업과제 주제 및 상담 일정 (마감)', 'http://his.pusan.ac.kr/bbs/cse/12549/1171831/artclView.do');
 
+
+
 INSERT INTO scrap_tb (`scrap_id`, `user_id`, `content_id`, `created_at`, `last_modified_at`)
 VALUES (1, 1, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO scrap_tb (`scrap_id`, `user_id`, `content_id`, `created_at`, `last_modified_at`)
@@ -141,4 +143,8 @@ INSERT INTO scrap_tb (`scrap_id`, `user_id`, `content_id`, `created_at`, `last_m
 VALUES (20, 1, 30, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO scrap_tb (`scrap_id`, `user_id`, `content_id`, `created_at`, `last_modified_at`)
 VALUES (21, 1, 31, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO scrap_tb (`scrap_id`, `user_id`, `content_id`, `created_at`, `last_modified_at`)
+VALUES (22, 1, 32, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO scrap_tb (`scrap_id`, `user_id`, `content_id`, `created_at`, `last_modified_at`)
+VALUES (23, 1, 33, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 

--- a/ppap/src/test/java/com/ppap/ppap/_core/DummyEntity.java
+++ b/ppap/src/test/java/com/ppap/ppap/_core/DummyEntity.java
@@ -75,6 +75,23 @@ public class DummyEntity {
         return testSubscribeList;
     }
 
+    public List<Subscribe> getTestSubscribeListWithPriority(User user, List<Notice> noticeList){
+        List<Subscribe> testSubscribeList = new ArrayList<>();
+        for(int i=0; i<noticeList.size(); i++) {
+            testSubscribeList.add(
+                Subscribe.builder()
+                    .id(i+1L)
+                    .title("테스트 " + (i+1))
+                    .user(user)
+                    .notice(noticeList.get(i))
+                    .noticeLink(null)
+                    .isActive(true)
+                    .priority(Integer.MAX_VALUE-i)
+                    .build());
+        }
+        return testSubscribeList;
+    }
+
     public List<Content> getTestContentList(Notice notice) {
         return List.of(
                 new Content(1L, notice, "컴퓨터 및 프로그래밍 입문(001분반, 조환규 교수님) 수업을 신청한 수강생은 꼭 읽어주세요.", "http://his.pusan.ac.kr/bbs/cse/2615/931071/artclView.do", LocalDateTime.parse("2022-02-28T18:30:17.097"), null, null),

--- a/ppap/src/test/java/com/ppap/ppap/controller/ContentControllerTest.java
+++ b/ppap/src/test/java/com/ppap/ppap/controller/ContentControllerTest.java
@@ -33,32 +33,31 @@ public class ContentControllerTest extends RestDocs {
                             .header(JwtProvider.HEADER, accessToken)
             );
             String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-//            System.out.println(responseBody);
 
             // then
             resultActions.andExpectAll(
                     jsonPath("$.success").value("true"),
-                    jsonPath("$.response.curSubscribeId").value(1L),
-                    jsonPath("$.response.contents[0].contentId").value(1L),
-                    jsonPath("$.response.contents[0].isScraped").value("true"),
-                    jsonPath("$.response.contents[1].contentId").value(2L),
+                    jsonPath("$.response.curSubscribeId").value(2L),
+                    jsonPath("$.response.contents[0].contentId").value(18L),
+                    jsonPath("$.response.contents[0].isScraped").value("false"),
+                    jsonPath("$.response.contents[1].contentId").value(19L),
                     jsonPath("$.response.contents[1].isScraped").value("true"),
-                    jsonPath("$.response.contents[2].contentId").value(3L),
-                    jsonPath("$.response.contents[2].isScraped").value("true"),
-                    jsonPath("$.response.contents[3].contentId").value(4L),
-                    jsonPath("$.response.contents[3].isScraped").value("false"),
-                    jsonPath("$.response.contents[4].contentId").value(5L),
-                    jsonPath("$.response.contents[4].isScraped").value("false"),
-                    jsonPath("$.response.contents[5].contentId").value(6L),
+                    jsonPath("$.response.contents[2].contentId").value(20L),
+                    jsonPath("$.response.contents[2].isScraped").value("false"),
+                    jsonPath("$.response.contents[3].contentId").value(21L),
+                    jsonPath("$.response.contents[3].isScraped").value("true"),
+                    jsonPath("$.response.contents[4].contentId").value(22L),
+                    jsonPath("$.response.contents[4].isScraped").value("true"),
+                    jsonPath("$.response.contents[5].contentId").value(23L),
                     jsonPath("$.response.contents[5].isScraped").value("true"),
-                    jsonPath("$.response.contents[6].contentId").value(7L),
+                    jsonPath("$.response.contents[6].contentId").value(24L),
                     jsonPath("$.response.contents[6].isScraped").value("true"),
-                    jsonPath("$.response.contents[7].contentId").value(8L),
-                    jsonPath("$.response.contents[7].isScraped").value("true"),
-                    jsonPath("$.response.contents[8].contentId").value(9L),
-                    jsonPath("$.response.contents[8].isScraped").value("true"),
-                    jsonPath("$.response.contents[9].contentId").value(10L),
-                    jsonPath("$.response.contents[9].isScraped").value("false"),
+                    jsonPath("$.response.contents[7].contentId").value(25L),
+                    jsonPath("$.response.contents[7].isScraped").value("false"),
+                    jsonPath("$.response.contents[8].contentId").value(26L),
+                    jsonPath("$.response.contents[8].isScraped").value("false"),
+                    jsonPath("$.response.contents[9].contentId").value(27L),
+                    jsonPath("$.response.contents[9].isScraped").value("true"),
                     jsonPath("$.error").doesNotExist()
             );
 
@@ -100,21 +99,19 @@ public class ContentControllerTest extends RestDocs {
             // then
             resultActions.andExpectAll(
                     jsonPath("$.success").value("true"),
-                    jsonPath("$.response.curSubscribeId").value(1L),
-                    jsonPath("$.response.contents[0].contentId").value(11L),
+                    jsonPath("$.response.curSubscribeId").value(2L),
+                    jsonPath("$.response.contents[0].contentId").value(28L),
                     jsonPath("$.response.contents[0].isScraped").value("true"),
-                    jsonPath("$.response.contents[1].contentId").value(12L),
+                    jsonPath("$.response.contents[1].contentId").value(29L),
                     jsonPath("$.response.contents[1].isScraped").value("true"),
-                    jsonPath("$.response.contents[2].contentId").value(13L),
-                    jsonPath("$.response.contents[2].isScraped").value("false"),
-                    jsonPath("$.response.contents[3].contentId").value(14L),
-                    jsonPath("$.response.contents[3].isScraped").value("false"),
-                    jsonPath("$.response.contents[4].contentId").value(15L),
+                    jsonPath("$.response.contents[2].contentId").value(30L),
+                    jsonPath("$.response.contents[2].isScraped").value("true"),
+                    jsonPath("$.response.contents[3].contentId").value(31L),
+                    jsonPath("$.response.contents[3].isScraped").value("true"),
+                    jsonPath("$.response.contents[4].contentId").value(32L),
                     jsonPath("$.response.contents[4].isScraped").value("true"),
-                    jsonPath("$.response.contents[5].contentId").value(16L),
-                    jsonPath("$.response.contents[5].isScraped").value("false"),
-                    jsonPath("$.response.contents[6].contentId").value(17L),
-                    jsonPath("$.response.contents[6].isScraped").value("true"),
+                    jsonPath("$.response.contents[5].contentId").value(33L),
+                    jsonPath("$.response.contents[5].isScraped").value("true"),
                     jsonPath("$.error").doesNotExist()
             );
         }

--- a/ppap/src/test/java/com/ppap/ppap/controller/ScrapControllerTest.java
+++ b/ppap/src/test/java/com/ppap/ppap/controller/ScrapControllerTest.java
@@ -188,17 +188,17 @@ public class ScrapControllerTest extends RestDocs {
             // then
             resultActions.andExpectAll(
                     jsonPath("$.success").value("true"),
-                    jsonPath("$.response.curSubscribeId").value(1L),
-                    jsonPath("$.response.scraps[0].contentId").value(1L),
-                    jsonPath("$.response.scraps[1].contentId").value(2L),
-                    jsonPath("$.response.scraps[2].contentId").value(3L),
-                    jsonPath("$.response.scraps[3].contentId").value(6L),
-                    jsonPath("$.response.scraps[4].contentId").value(7L),
-                    jsonPath("$.response.scraps[5].contentId").value(8L),
-                    jsonPath("$.response.scraps[6].contentId").value(9L),
-                    jsonPath("$.response.scraps[7].contentId").value(11L),
-                    jsonPath("$.response.scraps[8].contentId").value(12L),
-                    jsonPath("$.response.scraps[9].contentId").value(15L),
+                    jsonPath("$.response.curSubscribeId").value(2L),
+                    jsonPath("$.response.scraps[0].contentId").value(19L),
+                    jsonPath("$.response.scraps[1].contentId").value(21L),
+                    jsonPath("$.response.scraps[2].contentId").value(22L),
+                    jsonPath("$.response.scraps[3].contentId").value(23L),
+                    jsonPath("$.response.scraps[4].contentId").value(24L),
+                    jsonPath("$.response.scraps[5].contentId").value(27L),
+                    jsonPath("$.response.scraps[6].contentId").value(28L),
+                    jsonPath("$.response.scraps[7].contentId").value(29L),
+                    jsonPath("$.response.scraps[8].contentId").value(30L),
+                    jsonPath("$.response.scraps[9].contentId").value(31L),
                     jsonPath("$.error").doesNotExist()
             );
 
@@ -237,8 +237,9 @@ public class ScrapControllerTest extends RestDocs {
             // then
             resultActions.andExpectAll(
                     jsonPath("$.success").value("true"),
-                    jsonPath("$.response.curSubscribeId").value(1L),
-                    jsonPath("$.response.scraps[0].contentId").value(17L),
+                    jsonPath("$.response.curSubscribeId").value(2L),
+                    jsonPath("$.response.scraps[0].contentId").value(32L),
+                    jsonPath("$.response.scraps[1].contentId").value(33L),
                     jsonPath("$.error").doesNotExist()
             );
         }

--- a/ppap/src/test/java/com/ppap/ppap/controller/SubscribeControllerTest.java
+++ b/ppap/src/test/java/com/ppap/ppap/controller/SubscribeControllerTest.java
@@ -7,13 +7,19 @@ import com.ppap.ppap._core.RestDocs;
 import com.ppap.ppap._core.exception.BaseExceptionStatus;
 import com.ppap.ppap._core.utils.UrlFactory;
 import com.ppap.ppap._core.security.JwtProvider;
+import com.ppap.ppap.domain.subscribe.dto.SubscribeChangePriorityDto;
 import com.ppap.ppap.domain.subscribe.dto.SubscribeCreateRequestDto;
 import com.ppap.ppap.domain.subscribe.dto.SubscribeUpdateRequestDto;
+import com.ppap.ppap.domain.subscribe.entity.Subscribe;
+import com.ppap.ppap.domain.subscribe.service.SubscribeReadService;
+import com.ppap.ppap.domain.user.entity.User;
+
 import org.jdom2.Document;
 import org.jdom2.input.SAXBuilder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -21,9 +27,13 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.InputStream;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.IntStream;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -32,9 +42,15 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
+import jakarta.persistence.EntityManager;
+
 @DisplayName("구독 통합 테스트")
 public class SubscribeControllerTest extends RestDocs {
 
+    @Autowired
+    private SubscribeReadService subscribeReadService;
+    @Autowired
+    private EntityManager em;
 
     @MockBean
     private SAXBuilder saxBuilder;
@@ -210,14 +226,13 @@ public class SubscribeControllerTest extends RestDocs {
                             .header(JwtProvider.HEADER, accessToken)
             );
             String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-            System.out.println(responseBody);
 
             // then
             resultActions.andExpectAll(
                     jsonPath("$.success").value("true"),
-                    jsonPath("$.response[0].subscribeId").value(1),
-                    jsonPath("$.response[1].subscribeId").value(2),
-                    jsonPath("$.response[2].subscribeId").value(3),
+                    jsonPath("$.response[0].subscribeId").value(2),
+                    jsonPath("$.response[1].subscribeId").value(3),
+                    jsonPath("$.response[2].subscribeId").value(1),
                     jsonPath("$.error").doesNotExist()
             );
             resultActions.andDo(document(
@@ -667,6 +682,50 @@ public class SubscribeControllerTest extends RestDocs {
                     jsonPath("$.error.message").value(BaseExceptionStatus.SUBSCRIBE_FORBIDDEN.getMessage()),
                     jsonPath("$.error.status").value(BaseExceptionStatus.SUBSCRIBE_FORBIDDEN.getStatus())
             );
+        }
+    }
+
+    @DisplayName("구독 우선순위 변경 테스트")
+    @Nested
+    class ChangePriorityTest {
+        @DisplayName("성공")
+        @Test
+        void success() throws Exception {
+            // given
+            String accessToken = getAccessToken("rjsdnxogh@naver.com");
+            User user = getUser("rjsdnxogh@naver.com");
+            List<Subscribe> beforeSubscribeList = subscribeReadService.getSubscribeEntityList(user)
+                .stream()
+                .sorted(Comparator.comparing(Subscribe::getId))
+                .toList();
+            SubscribeChangePriorityDto subscribeChangePriorityDto = new SubscribeChangePriorityDto(
+                beforeSubscribeList.stream()
+                    .map(Subscribe::getId)
+                    .toList()
+            );
+            String requestBody = om.writeValueAsString(subscribeChangePriorityDto);
+
+            // when
+            ResultActions resultActions = mvc.perform(
+                post("/api/v0/subscribe/change/priority")
+                    .content(requestBody)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(JwtProvider.HEADER, accessToken)
+            );
+            // then
+            resultActions.andExpectAll(
+                jsonPath("$.success").value("true"),
+                jsonPath("$.response").doesNotExist(),
+                jsonPath("$.error").doesNotExist()
+            );
+
+            em.clear();
+            List<Subscribe> afterSubscribeList = subscribeReadService.getSubscribeEntityList(user);
+            IntStream.range(0, afterSubscribeList.size())
+                .forEach( i -> {
+                    assertEquals(beforeSubscribeList.get(i), afterSubscribeList.get(i));
+                    assertEquals(i, afterSubscribeList.get(i).getPriority());
+                });
         }
     }
 }

--- a/ppap/src/test/java/com/ppap/ppap/controller/SubscribeControllerTest.java
+++ b/ppap/src/test/java/com/ppap/ppap/controller/SubscribeControllerTest.java
@@ -559,7 +559,6 @@ public class SubscribeControllerTest extends RestDocs {
             );
 
             String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-            System.out.println(responseBody);
 
             // then
             resultActions.andExpectAll(
@@ -704,7 +703,7 @@ public class SubscribeControllerTest extends RestDocs {
                     .toList()
             );
             String requestBody = om.writeValueAsString(subscribeChangePriorityDto);
-
+            System.out.println(requestBody);
             // when
             ResultActions resultActions = mvc.perform(
                 post("/api/v0/subscribe/change/priority")
@@ -726,6 +725,21 @@ public class SubscribeControllerTest extends RestDocs {
                     assertEquals(beforeSubscribeList.get(i), afterSubscribeList.get(i));
                     assertEquals(i, afterSubscribeList.get(i).getPriority());
                 });
+
+            resultActions.andDo(document(
+                snippet,
+                getDocumentRequest(),
+                getDocumentResponse(),
+                resource(ResourceSnippetParameters.builder()
+                    .description("구독 우선순위 변경 API")
+                    .requestHeaders(
+                        headerWithName(JwtProvider.HEADER).type(SimpleType.STRING).description("access 토큰")
+                    )
+                    .requestFields(
+                        fieldWithPath("subscribeIds").type(JsonFieldType.ARRAY).description("자연수로 이루어진 구독 ID 목록")
+                    )
+                    .build())
+            ));
         }
     }
 }

--- a/ppap/src/test/java/com/ppap/ppap/service/subscribe/SubscribeWriteServiceTest.java
+++ b/ppap/src/test/java/com/ppap/ppap/service/subscribe/SubscribeWriteServiceTest.java
@@ -30,6 +30,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -419,4 +420,33 @@ public class SubscribeWriteServiceTest {
         }
     }
 
+    @DisplayName("구독 우선순위 변경 테스트")
+    @Nested
+    class ChangePriorityTest {
+
+        @DisplayName("성공")
+        @Test
+        void success() {
+            // given
+            User user = dummyEntity.getTestUser("rjsdnxogh@navr.com", 1L);
+            List<Notice> testNoticeList = dummyEntity.getTestNoticeList();
+            List<Subscribe> testSubscribeList = dummyEntity.getTestSubscribeListWithPriority(user, testNoticeList);
+            List<Long> testSubscribeIds = testSubscribeList.stream()
+                .map(Subscribe::getId)
+                .toList();
+
+            // mock
+            given(subscribeJpaRepository.findAllById(testSubscribeIds)).willReturn(testSubscribeList);
+
+            // when
+            subscribeWriteService.changePriority(testSubscribeIds, user);
+
+            // then
+            IntStream.range(0, testSubscribeList.size())
+                .forEach(i -> {
+                    assertEquals(i, testSubscribeList.get(i).getPriority());
+                });
+
+        }
+    }
 }


### PR DESCRIPTION
close #56
---
## 다음과 같은 구현사항이 있습니다.
1. 구독 엔티티에 Priority 필드를 추가했습니다.
2. 구독, 컨텐츠, 스크랩 목록에 구독의 Priority를 기준으로 정렬하는 로직을 추가했습니다.
3. 구독에 대해서 Priority를 설정하는 API를 추가했습니다.